### PR TITLE
Revert "Do not override buffer current syntax."

### DIFF
--- a/ftdetect/rspec.vim
+++ b/ftdetect/rspec.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *_spec.rb let &l:syntax = &syntax . '.rspec'
+autocmd BufNewFile,BufRead *_spec.rb set syntax=rspec

--- a/syntax/rspec.vim
+++ b/syntax/rspec.vim
@@ -4,7 +4,7 @@
 "
 "
 
-let b:old_syntax = b:current_syntax
+runtime! syntax/ruby.vim
 unlet! b:current_syntax
 
 setlocal commentstring=#\ %s
@@ -37,5 +37,4 @@ highlight link rspecMatchers Function
 syntax keyword rspecMessageExpectation advise any_args any_number_of_times anything at_least at_most exactly expected_messages_received generate_error hash_including hash_not_including ignoring_args instance_of matches_at_least_count matches_at_most_count matches_exact_count matches_name_but_not_args negative_expectation_for never no_args once ordered similar_messages times twice verify_messages_received with
 highlight link rspecMessageExpectation Function
 
-let b:current_syntax = b:old_syntax . '.rspec'
-unlet b:old_syntax
+let b:current_syntax = 'rspec'


### PR DESCRIPTION
Reverts keith/rspec.vim#22

Reverting because of https://github.com/keith/rspec.vim/issues/23

@kassio if you have time to fix this we can merge it again. Probably just need to verify current syntax exists first. Unfortunately I can't right now.