### PR TITLE
Highlight focus shorthand methods

### DIFF
--- a/syntax/rspec.vim
+++ b/syntax/rspec.vim
@@ -14,6 +14,12 @@ syntax keyword rspecGroupMethods
       \ describe
       \ example
       \ feature
+      \ fcontext
+      \ fdescribe
+      \ fexample
+      \ fit
+      \ focus
+      \ fspecify
       \ Given
       \ given\!
       \ include_context


### PR DESCRIPTION
See (http://www.rubydoc.info/github/rspec/rspec-core/RSpec/Core/ExampleGroup#fit-class_method) for documentation on the additional methods.