### PR TITLE
Force filetype=rspec.ruby so UltiSnips works for both.

### DIFF
--- a/ftdetect/rspec.vim
+++ b/ftdetect/rspec.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *_spec.rb set syntax=rspec
+autocmd BufNewFile,BufRead *_spec.rb set syntax=rspec filetype=rspec.ruby


### PR DESCRIPTION
Without the change, UltiSnips doesn't pick up RSpec specific snippets. With the change, both RSpec and Ruby snippets are loaded.
