### PR TITLE
Treat aggregate_failures as a keyword

### DIFF
--- a/syntax/rspec.vim
+++ b/syntax/rspec.vim
@@ -10,6 +10,7 @@ unlet! b:current_syntax
 setlocal commentstring=#\ %s
 
 syntax keyword rspecGroupMethods
+      \ aggregate_failures
       \ context
       \ describe
       \ example


### PR DESCRIPTION
RSpec's `aggregate_failures` feature is really useful. This change
highlights it so that it shows as a grouping of expectations.